### PR TITLE
Upgrade to Polly v8, add ".WithPipeline()" methods

### DIFF
--- a/PollyFlurl/PollyFlurl.csproj
+++ b/PollyFlurl/PollyFlurl.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <None Include="..\README.md" Pack="true" PackagePath="\" />
     <PackageReference Include="Flurl.Http" Version="4.0.0-pre2" />
-    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="Polly" Version="8.4.1" />
   </ItemGroup>
 
 </Project>

--- a/PollyFlurl/PollyFlurlExtensions.cs
+++ b/PollyFlurl/PollyFlurlExtensions.cs
@@ -1,27 +1,30 @@
-﻿using System.Net;
+﻿using Polly.Retry;
+using System.Net;
 
 namespace PollyFlurl;
 public static class PollyFlurlExtensions
 {
-    public static IFlurlRequest WithPolicy(this string request, IAsyncPolicy<IFlurlResponse> policy) => WithPolicy(new Url(request), policy);
-    public static IFlurlRequest WithPolicy(this Url request, IAsyncPolicy<IFlurlResponse> policy) => WithPolicy(new FlurlRequest(request), policy);
-    public static IFlurlRequest WithPolicy(this IFlurlRequest request, IAsyncPolicy<IFlurlResponse> policy)
+    #region ResiliencePipeline
+
+    public static IFlurlRequest WithPipeline(this string request, ResiliencePipeline<IFlurlResponse> pipeline) => WithPipeline(new Url(request), pipeline);
+    public static IFlurlRequest WithPipeline(this Url request, ResiliencePipeline<IFlurlResponse> pipeline) => WithPipeline(new FlurlRequest(request), pipeline);
+    public static IFlurlRequest WithPipeline(this IFlurlRequest request, ResiliencePipeline<IFlurlResponse> pipeline)
     {
-        return new PollyRequestFlurlResponse(request, policy);
+        return new PollyPipelineRequestFlurlResponse(request, pipeline);
     }
 
-    public static IFlurlRequest WithPolicy(this string request, IAsyncPolicy policy) => WithPolicy(new Url(request), policy);
-    public static IFlurlRequest WithPolicy(this Url request, IAsyncPolicy policy) => WithPolicy(new FlurlRequest(request), policy);
-    public static IFlurlRequest WithPolicy(this IFlurlRequest request, IAsyncPolicy policy)
+    public static IFlurlRequest WithPipeline(this string request, ResiliencePipeline pipeline) => WithPipeline(new Url(request), pipeline);
+    public static IFlurlRequest WithPipeline(this Url request, ResiliencePipeline pipeline) => WithPipeline(new FlurlRequest(request), pipeline);
+    public static IFlurlRequest WithPipeline(this IFlurlRequest request, ResiliencePipeline pipeline)
     {
-        return new PollyRequest(request, policy);
+        return new PollyPipelineRequest(request, pipeline);
     }
 
-    public static IFlurlRequest WithPolicy(this string request, IAsyncPolicy<HttpResponseMessage> policy) => WithPolicy(new Url(request), policy);
-    public static IFlurlRequest WithPolicy(this Url request, IAsyncPolicy<HttpResponseMessage> policy) => WithPolicy(new FlurlRequest(request), policy);
-    public static IFlurlRequest WithPolicy(this IFlurlRequest request, IAsyncPolicy<HttpResponseMessage> policy)
+    public static IFlurlRequest WithPipeline(this string request, ResiliencePipeline<HttpResponseMessage> pipeline) => WithPipeline(new Url(request), pipeline);
+    public static IFlurlRequest WithPipeline(this Url request, ResiliencePipeline<HttpResponseMessage> pipeline) => WithPipeline(new FlurlRequest(request), pipeline);
+    public static IFlurlRequest WithPipeline(this IFlurlRequest request, ResiliencePipeline<HttpResponseMessage> pipeline)
     {
-        return new PollyHttpResponseRequest(request, policy);
+        return new PollyPipelineHttpResponseRequest(request, pipeline);
     }
 
     static readonly HttpStatusCode[] httpStatusCodesWorthRetrying = {
@@ -34,10 +37,55 @@ public static class PollyFlurlExtensions
 
     public static IFlurlRequest RetryTransientErrors(this string request) => RetryTransientErrors(new Url(request));
     public static IFlurlRequest RetryTransientErrors(this Url request) => RetryTransientErrors(new FlurlRequest(request));
-    public static IFlurlRequest RetryTransientErrors(this IFlurlRequest request) =>
-        WithPolicy(request,
-            Policy
-                .Handle<HttpRequestException>()
-                .OrResult<HttpResponseMessage>(r => httpStatusCodesWorthRetrying.Contains(r.StatusCode))
-                .RetryAsync());
+    public static IFlurlRequest RetryTransientErrors(this IFlurlRequest request) => WithPipeline(request, defaultRetryPipeline.Value);
+
+    private static readonly Lazy<ResiliencePipeline<HttpResponseMessage>> defaultRetryPipeline = new Lazy<ResiliencePipeline<HttpResponseMessage>>(() =>
+    {
+        return new ResiliencePipelineBuilder<HttpResponseMessage>()
+            .AddRetry(new RetryStrategyOptions<HttpResponseMessage>()
+            {
+                ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
+                    .Handle<HttpRequestException>()
+                    .HandleResult(r => httpStatusCodesWorthRetrying.Contains(r.StatusCode))
+            })
+            .Build();
+    });
+
+    #endregion
+
+    #region Policy (legacy)
+
+    const string WithPolicyObsoleteWarning = @"Use "".WithPipeline(ResiliencePipeline pipeline)"" instead. See Polly v8's doc for more info: https://www.pollydocs.org/migration-v8.html#configuring-strategies-in-v8";
+
+    [Obsolete(WithPolicyObsoleteWarning)]
+    public static IFlurlRequest WithPolicy(this string request, IAsyncPolicy<IFlurlResponse> policy) => WithPolicy(new Url(request), policy);
+    [Obsolete(WithPolicyObsoleteWarning)]
+    public static IFlurlRequest WithPolicy(this Url request, IAsyncPolicy<IFlurlResponse> policy) => WithPolicy(new FlurlRequest(request), policy);
+    [Obsolete(WithPolicyObsoleteWarning)]
+    public static IFlurlRequest WithPolicy(this IFlurlRequest request, IAsyncPolicy<IFlurlResponse> policy)
+    {
+        return new PollyPolicyRequestFlurlResponse(request, policy);
+    }
+
+    [Obsolete(WithPolicyObsoleteWarning)]
+    public static IFlurlRequest WithPolicy(this string request, IAsyncPolicy policy) => WithPolicy(new Url(request), policy);
+    [Obsolete(WithPolicyObsoleteWarning)]
+    public static IFlurlRequest WithPolicy(this Url request, IAsyncPolicy policy) => WithPolicy(new FlurlRequest(request), policy);
+    [Obsolete(WithPolicyObsoleteWarning)]
+    public static IFlurlRequest WithPolicy(this IFlurlRequest request, IAsyncPolicy policy)
+    {
+        return new PollyPolicyRequest(request, policy);
+    }
+
+    [Obsolete(WithPolicyObsoleteWarning)]
+    public static IFlurlRequest WithPolicy(this string request, IAsyncPolicy<HttpResponseMessage> policy) => WithPolicy(new Url(request), policy);
+    [Obsolete(WithPolicyObsoleteWarning)]
+    public static IFlurlRequest WithPolicy(this Url request, IAsyncPolicy<HttpResponseMessage> policy) => WithPolicy(new FlurlRequest(request), policy);
+    [Obsolete(WithPolicyObsoleteWarning)]
+    public static IFlurlRequest WithPolicy(this IFlurlRequest request, IAsyncPolicy<HttpResponseMessage> policy)
+    {
+        return new PollyPolicyHttpResponseRequest(request, policy);
+    }
+
+    #endregion
 }

--- a/PollyFlurl/PollyFlurlExtensions.cs
+++ b/PollyFlurl/PollyFlurlExtensions.cs
@@ -55,7 +55,7 @@ public static class PollyFlurlExtensions
 
     #region Policy (legacy)
 
-    const string WithPolicyObsoleteWarning = @"Use "".WithPipeline(ResiliencePipeline pipeline)"" instead. See Polly v8's doc for more info: https://www.pollydocs.org/migration-v8.html#configuring-strategies-in-v8";
+    private const string WithPolicyObsoleteWarning = @"Use "".WithPipeline(ResiliencePipeline pipeline)"" instead. See Polly v8's doc for more info: https://www.pollydocs.org/migration-v8.html#configuring-strategies-in-v8";
 
     [Obsolete(WithPolicyObsoleteWarning)]
     public static IFlurlRequest WithPolicy(this string request, IAsyncPolicy<IFlurlResponse> policy) => WithPolicy(new Url(request), policy);

--- a/Test/BasicTests.cs
+++ b/Test/BasicTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using Flurl.Http.Testing;
 using Polly;
+using Polly.Retry;
 using PollyFlurl;
 using Xunit.Abstractions;
 
@@ -25,6 +26,88 @@ public class BasicTests
         response.StatusCode.Should().Be(200);
     }
 
+    #region ResiliencePipeline
+
+    [Fact]
+    public async Task CustomPipeline_HandleHTTPResponseMessage()
+    {
+        using var httpTest = new HttpTest();
+        httpTest.RespondWith("Bad Request", status: 500);
+        httpTest.RespondWith("", status: 200);
+
+        var pipeline = new ResiliencePipelineBuilder<HttpResponseMessage>()
+            .AddRetry(new RetryStrategyOptions<HttpResponseMessage>()
+            {
+                ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
+                    .HandleResult(message =>
+                    {
+                        var content = message.Content.ReadAsStringAsync().Result;
+                        return content == "Bad Request";
+                    })
+            })
+            .Build();
+
+        var response = await "http://www.google.com"
+            .WithPipeline(pipeline)
+            .GetAsync();
+        response.StatusCode.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task CustomPipeline_HandleResponse()
+    {
+        using var httpTest = new HttpTest();
+        httpTest.RespondWith("Bad Request", status: 500);
+        httpTest.RespondWith("", status: 200);
+
+        var pipeline = new ResiliencePipelineBuilder<IFlurlResponse>()
+            .AddRetry(new RetryStrategyOptions<IFlurlResponse>()
+            {
+                ShouldHandle = new PredicateBuilder<IFlurlResponse>()
+                    .HandleResult(message =>
+                    {
+                        var content = message.GetStringAsync().Result;
+                        return content == "Bad Request";
+                    })
+            })
+            .Build();
+
+        var response = await "http://www.google.com"
+            .AllowAnyHttpStatus() // otherwise raised as an exception
+            .WithPipeline(pipeline)
+            .GetAsync();
+        response.StatusCode.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task CustomPipeline_HandleException()
+    {
+        using var httpTest = new HttpTest();
+        httpTest.RespondWith("Bad Request", status: 500);
+        httpTest.RespondWith("", status: 200);
+
+        var pipeline = new ResiliencePipelineBuilder()
+            .AddRetry(new RetryStrategyOptions()
+            {
+                ShouldHandle = new PredicateBuilder()
+                    .Handle<FlurlHttpException>(ex =>
+                    {
+                        var content = ex.Call.Response.GetStringAsync().Result;
+                        return content == "Bad Request";
+                    })
+            })
+            .Build();
+
+        var response = await "http://www.google.com"
+            .WithPipeline(pipeline)
+            .GetAsync();
+        response.StatusCode.Should().Be(200);
+    }
+
+    #endregion
+
+    #region Policy (legacy)
+
     [Fact]
     public async Task CustomPolicy_HandleHTTPResponseMessage()
     {
@@ -40,9 +123,11 @@ public class BasicTests
             })
             .RetryAsync();
 
+#pragma warning disable CS0618 // ".WithPolicy()" is obsolete
         var response = await "http://www.google.com"
             .WithPolicy(policy)
             .GetAsync();
+#pragma warning restore CS0618 // ".WithPolicy()" is obsolete
         response.StatusCode.Should().Be(200);
     }
 
@@ -61,10 +146,12 @@ public class BasicTests
             })
             .RetryAsync();
 
+#pragma warning disable CS0618 // ".WithPolicy()" is obsolete
         var response = await "http://www.google.com"
             .AllowAnyHttpStatus() // otherwise raised as an exception
             .WithPolicy(policy)
             .GetAsync();
+#pragma warning restore CS0618 // ".WithPolicy()" is obsolete
         response.StatusCode.Should().Be(200);
     }
 
@@ -83,9 +170,13 @@ public class BasicTests
             })
             .RetryAsync();
 
+#pragma warning disable CS0618 // ".WithPolicy()" is obsolete
         var response = await "http://www.google.com"
             .WithPolicy(policy)
             .GetAsync();
+#pragma warning restore CS0618 // ".WithPolicy()" is obsolete
         response.StatusCode.Should().Be(200);
     }
+
+    #endregion
 }


### PR DESCRIPTION
Hi, I saw this lib in https://github.com/tmenier/Flurl/issues/346#issuecomment-1193443761. Thank you for creating it!

In Polly v8, `Policy` is described as "legacy API". It's recommended to use `ResiliencePipeline` instead, according to the [documentation](https://www.pollydocs.org/migration-v8.html#configuring-strategies-in-v8).

This pull request: 

- Upgrades Polly to `8.4.1` from `7.2.3`
- Adds `.WithPipeline(ResiliencePipeline pipeline)` extension methods
- Marks `.WithPolicy(Policy policy)` methods as obsolete

Before:
```cs
var policy = Policy
    .HandleResult<HttpResponseMessage>(message =>
    {
        var content = message.Content.ReadAsStringAsync().Result;
        return content == "Bad Request";
    })
    .RetryAsync();

var response = await "http://www.google.com"
    .WithPolicy(policy)
    .GetAsync();
response.StatusCode.Should().Be(200);
```

After:
```cs
var pipeline = new ResiliencePipelineBuilder<HttpResponseMessage>()
    .AddRetry(new RetryStrategyOptions<HttpResponseMessage>()
    {
        ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
            .HandleResult(message =>
            {
                var content = message.Content.ReadAsStringAsync().Result;
                return content == "Bad Request";
            })
    })
    .Build();

var response = await "http://www.google.com"
    .WithPipeline(pipeline)    // 👈 Change
    .GetAsync();
response.StatusCode.Should().Be(200);

```